### PR TITLE
Wip lazy init

### DIFF
--- a/priv/lib/js/zotonic.teleview.worker.js
+++ b/priv/lib/js/zotonic.teleview.worker.js
@@ -56,7 +56,7 @@ model.present = function(proposal) {
         model.encoder = new TextEncoder();
         model.decoder = new TextDecoder();
 
-        model.keyframe = model.encoder.encode(arg.keyframe);
+        model.keyframe = (arg.keyframe === undefined) ? undefined : model.encoder.encode(arg.keyframe);
         model.keyframe_sn = arg.keyframe_sn;
 
         model.current_frame = (arg.current_frame === undefined) ? undefined : model.encoder.encode(arg.current_frame);

--- a/priv/lib/js/zotonic.teleview.worker.js
+++ b/priv/lib/js/zotonic.teleview.worker.js
@@ -32,7 +32,7 @@ function initialState() {
     };
 }
 
-const model = initialState();
+let model = initialState();
 const view = {};
 const state = {};
 const actions = {};

--- a/priv/lib/js/zotonic.teleview.worker.js
+++ b/priv/lib/js/zotonic.teleview.worker.js
@@ -121,17 +121,11 @@ model.present = function(proposal) {
                 model.isCurrentFrameRequested = false;
 
                 if(model.current_frame_sn === undefined || proposal.update.current_frame_sn > model.current_frame_sn) {
-                    console.log("new current", proposal.update.current_frame_sn);
-
                     model.current_frame = model.encoder.encode(proposal.update.current_frame);
                     model.current_frame_sn = proposal.update.current_frame_sn;
 
-                    console.log("patch queue", model.incrementalPatchQueue.length);
-
                     while(model.incrementalPatchQueue.length) {
                         const p = model.incrementalPatchQueue.shift();
-
-                        console.log("patch", p);
 
                         if(model.current_frame_sn + 1 !== p.current_frame_sn) continue; // skip
 
@@ -335,8 +329,6 @@ actions.rendererEvent = function(m, a) {
 }
 
 actions.update = function (type, update) {
-    console.log("update", type, update);
-
     model.present({
         is_update: true,
         type: type,
@@ -394,9 +386,6 @@ actions.lifecycleEvent = function(m, a) {
 
 actions.keyframeResponse = function(m) {
     const p = m.payload;
-
-    console.log("keyframe", m);
-
     if(p.status === "ok") {
         model.present({
             type: "keyframe",
@@ -404,14 +393,10 @@ actions.keyframeResponse = function(m) {
             update: p.result
         });
     }
-
 }
 
 actions.currentFrameResponse = function(m) {
     const p = m.payload;
-
-    console.log("current_frame", m);
-
     if(p.status === "ok") {
         model.present({
             type: "current_frame",
@@ -419,8 +404,6 @@ actions.currentFrameResponse = function(m) {
             update: p.result
         });
     }
-
-    console.log("currentFrame", m);
 }
 
 /**

--- a/src/mod_teleview.erl
+++ b/src/mod_teleview.erl
@@ -183,6 +183,7 @@ init(Args) ->
               {module, ?MODULE}
              ]),
 
+    z_teleview_state:init_table(Context),
     z_teleview_acl:init_table(Context),
 
     TeleviewSpec = #{id => z_teleview_sup,

--- a/src/mod_teleview.erl
+++ b/src/mod_teleview.erl
@@ -106,11 +106,12 @@ stop_teleview(Id, Context) ->
 
 % @doc Start a new renderer belonging to a teleview. The passed args and context are
 % used for rendering. The teleview must already be started earlier.
+-spec start_renderer(integer(), map(), zotonic:context()) -> {ok, integer()} | {error, _}.
 start_renderer(TeleviewId, Args, Context) ->
     case z_teleview_state:start_renderer(TeleviewId, Args, Context) of
-        {ok, #{ teleview_id := TeleviewId, renderer_id := RendererId }=RendererArgs} ->
+        {ok, RendererId} ->
             z_teleview_acl:ensure_renderer_access(TeleviewId, RendererId, Context),
-            {ok, RendererArgs};
+            {ok, RendererId};
         Error ->
             Error 
     end.

--- a/src/mod_teleview.erl
+++ b/src/mod_teleview.erl
@@ -22,7 +22,7 @@
 -mod_title("TeleView").
 -mod_description("Provides server rendered live updating views").
 -mod_provides([teleview]).
--mod_depends([base, mod_mqtt]).
+-mod_depends([base, mod_mqtt, mod_server_storage]).
 -mod_prio(1000).
 
 -behaviour(supervisor).
@@ -34,7 +34,7 @@
 
 -export([
     observe_acl_is_allowed/2,
-    observe_tick_1m/2,
+    observe_tick_10m/2,
 
     start_teleview/2,
     stop_teleview/2,
@@ -149,7 +149,7 @@ observe_acl_is_allowed(#acl_is_allowed{}, _Context) ->
     undefined.
 
 % @doc Cleanup the acl table
-observe_tick_1m(tick_1m, Context) ->
+observe_tick_10m(tick_10m, Context) ->
     z_teleview_acl:cleanup_table(Context).
 
 % @doc Return the number of televiews

--- a/src/models/m_teleview.erl
+++ b/src/models/m_teleview.erl
@@ -67,6 +67,30 @@ m_get([Teleview, <<"state">>, Renderer | Rest], Msg, Context) ->
             {ok, {Result, Rest}}
     end;
 
+%% Request for the keyframe
+m_get([Teleview, <<"keyframe">>, Renderer | Rest], _Msg, Context) ->
+    TeleviewId = z_convert:to_integer(Teleview),
+    RendererId = z_convert:to_integer(Renderer),
+
+    case z_teleview_acl:is_view_allowed(TeleviewId, RendererId, Context) of
+        true ->
+            {ok, {z_teleview_state:get_keyframe(TeleviewId, RendererId, Context), Rest}};
+        false ->
+            {error, eaccess}
+    end;
+
+%% Request for the current frame
+m_get([Teleview, <<"current_frame">>, Renderer | Rest], _Msg, Context) ->
+    TeleviewId = z_convert:to_integer(Teleview),
+    RendererId = z_convert:to_integer(Renderer),
+
+    case z_teleview_acl:is_view_allowed(TeleviewId, RendererId, Context) of
+        true ->
+            {ok, {z_teleview_state:get_current_frame(TeleviewId, RendererId, Context), Rest}};
+        false ->
+            {error, eaccess}
+    end;
+
 m_get(V, _Msg, _Context) ->
     lager:info("Unknown ~p lookup: ~p", [?MODULE, V]),
     {error, unknown_path}.

--- a/src/models/m_teleview.erl
+++ b/src/models/m_teleview.erl
@@ -65,7 +65,8 @@ m_get([Teleview, <<"keyframe">>, Renderer | Rest], _Msg, Context) ->
 
     case z_teleview_acl:is_view_allowed(TeleviewId, RendererId, Context) of
         true ->
-            {ok, {z_teleview_state:get_keyframe(TeleviewId, RendererId, Context), Rest}};
+            Frame = z_teleview_state:get_keyframe(TeleviewId, RendererId, Context),
+            {ok, {Frame, Rest}};
         false ->
             {error, eaccess}
     end;
@@ -78,7 +79,7 @@ m_get([Teleview, <<"current_frame">>, Renderer | Rest], _Msg, Context) ->
     case z_teleview_acl:is_view_allowed(TeleviewId, RendererId, Context) of
         true ->
             Frame = z_teleview_state:get_current_frame(TeleviewId, RendererId, Context),
-            {ok, {Frame, Context), Rest}};
+            {ok, {Frame, Rest}};
         false ->
             {error, eaccess}
     end;
@@ -91,7 +92,7 @@ m_get(V, _Msg, _Context) ->
 %% Model Posts
 %%
 
-m_post([Teleview, <<"still_watching">>, Renderer | _Rest], _Msg, Context) ->
+m_post([Teleview, <<"still_watching">>, Renderer], _Msg, Context) ->
     TeleviewId = z_convert:to_integer(Teleview),
     RendererId = z_convert:to_integer(Renderer),
 

--- a/src/models/m_teleview.erl
+++ b/src/models/m_teleview.erl
@@ -43,7 +43,6 @@
 %%
 %% model/teleview/post/<teleview-id>/still-watching/<renderer-id>      : Indicate that the viewer is still watching.
 %%
-%%
 %% model/teleview/event/<teleview-id>/stopped                          : The whole teleview is stopped. (e.g. when all renderers are gone) 
 %% model/teleview/event/<teleview-id>/started                          : The teleview is started. 
 %%

--- a/src/scomps/scomp_teleview_teleview.erl
+++ b/src/scomps/scomp_teleview_teleview.erl
@@ -1,5 +1,5 @@
 %% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
-%% @copyright 2019 Maas-Maarten Zeeman
+%% @copyright 2019-2021 Maas-Maarten Zeeman
 %% @doc Put a teleview on the page.
 
 %% Copyright 2019-2021 Maas-Maarten Zeeman
@@ -41,9 +41,9 @@ render(Params, _Vars, Context) ->
             {error, Error};
         {ok, TeleviewId} ->
             {ok, RenderState} = mod_teleview:start_renderer(TeleviewId, Vary, Context),
-
+            RenderState1 = maps:without([keyframe, keyframe_sn, current_frame, current_frame_sn], RenderState),
             Pickle = z_utils:pickle(#{ args => Args1, vary => Vary }, Context), 
-            render_teleview(maps:put(pickle, Pickle, RenderState), Params, Context)
+            render_teleview(maps:put(pickle, Pickle, RenderState1), Params, Context)
     end.
 
 %%

--- a/src/scomps/scomp_teleview_teleview.erl
+++ b/src/scomps/scomp_teleview_teleview.erl
@@ -39,6 +39,7 @@ render(Params, _Vars, Context) ->
     case mod_teleview:start_teleview(Args1, Context) of
         {ok, TeleviewId} ->
             {ok, RendererId} = mod_teleview:start_renderer(TeleviewId, Vary, Context),
+
             Pickle = z_utils:pickle(#{ args => Args1, vary => Vary }, Context), 
             render_teleview(maps:put(pickle, Pickle, #{ teleview_id => TeleviewId, renderer_id => RendererId }), Params, Context);
         {error, _E}=Error ->
@@ -71,7 +72,11 @@ render_teleview(#{ teleview_id := TeleviewId, renderer_id := RendererId }=Render
                    end,
 
     ArgsJSON = z_json:encode(Args),
-    Div = z_tags:render_tag(<<"div">>, [{<<"id">>, Id}], [ CurrentFrame ]),
+
+    Div = z_tags:render_tag(<<"div">>, [{<<"id">>, Id},
+                                        {<<"data-renderer-id">>, RendererId},
+                                        {<<"data-teleview-id">>, TeleviewId}],
+                            [ CurrentFrame ]),
     Spawn = [ <<"cotonic.spawn_named(\"">>, z_utils:js_escape(Name), "\", \"", SrcUrl, "\", \"", BaseUrl, "\",", ArgsJSON, ");" ],
 
     Script = z_tags:render_tag(<<"script">>, [],

--- a/src/scomps/scomp_teleview_teleview.erl
+++ b/src/scomps/scomp_teleview_teleview.erl
@@ -41,6 +41,7 @@ render(Params, _Vars, Context) ->
             {error, Error};
         {ok, TeleviewId} ->
             {ok, RenderState} = mod_teleview:start_renderer(TeleviewId, Vary, Context),
+
             Pickle = z_utils:pickle(#{ args => Args1, vary => Vary }, Context), 
             render_teleview(maps:put(pickle, Pickle, RenderState), Params, Context)
     end.

--- a/src/scomps/scomp_teleview_teleview.erl
+++ b/src/scomps/scomp_teleview_teleview.erl
@@ -50,7 +50,7 @@ render(Params, _Vars, Context) ->
 %% Helpers
 %%
 
-render_teleview(RenderState, Params, Context) ->
+render_teleview(#{ teleview_id := TeleviewId, renderer_id := RendererId }=RenderState, Params, Context) ->
     Id = z_ids:identifier(),
 
     %% Remove the language, to remove the lang element from the urls generated below.
@@ -58,7 +58,12 @@ render_teleview(RenderState, Params, Context) ->
 
     RenderState1 = maps:put(uiId, Id, RenderState),
 
-    CurrentFrame = maps:get(current_frame, RenderState1, <<>>),
+    CurrentFrame = case z_teleview_state:get_current_frame(TeleviewId, RendererId, Context) of
+                       #{ current_frame := Frame } ->
+                           Frame;
+                       _ ->
+                           <<>>
+                   end,
 
     Args = case maps:get(min_time, RenderState1, undefined) of
                0 ->

--- a/src/support/z_teleview_acl.erl
+++ b/src/support/z_teleview_acl.erl
@@ -29,6 +29,8 @@
     ensure_renderer_access/3,
     ensure_renderer_access/4,
 
+    is_view_allowed/3,
+
     is_event_subscribe_allowed/2,
     is_event_subscribe_allowed/3
 ]).
@@ -64,6 +66,12 @@ ensure_renderer_access(TeleviewId, RendererId, Context) ->
 
 ensure_renderer_access(Key, TeleviewId, RendererId, Context) ->
     ensure_entry(Key, renderer_entry(TeleviewId, RendererId), Context).
+
+
+%%
+is_view_allowed(TeleviewId, RendererId, Context) ->
+    Key = acl_key(Context),
+    is_entry_found(Key, renderer_entry(TeleviewId, RendererId), Context).
 
 
 %% Subscribe on the teleview event topic

--- a/src/support/z_teleview_acl.erl
+++ b/src/support/z_teleview_acl.erl
@@ -174,7 +174,7 @@ is_entry_found(Key, Entry, Context) ->
     end.
 
 table_name(Context) ->
-    list_to_atom("teleview$" ++ atom_to_list(z_context:site(Context))).
+    z_utils:name_for_site(?MODULE, Context).      
 
 acl_key(Context) ->
     case z_context:session_id(Context) of

--- a/src/support/z_teleview_differ.erl
+++ b/src/support/z_teleview_differ.erl
@@ -119,8 +119,7 @@ handle_call({new_frame, Frame}, _From, #state{processing=false}=State) ->
 
 handle_call({sync_new_frame, Frame}, _From, #state{}=State) ->
     {_Patch, State1} = next_patch(Frame, State),
-    {reply, differ_state(State1), State1#state{processing=false, new_frame=undefined}};
-
+    {reply, ok, State1#state{processing=false, new_frame=undefined}};
 
 handle_call(state, _From, State) ->
     {reply, differ_state(State), State};

--- a/src/support/z_teleview_differ.erl
+++ b/src/support/z_teleview_differ.erl
@@ -98,8 +98,8 @@ init([TeleviewId, RendererId, Args, Context]) ->
     % When we restarted because of an error, the viewers should be reset.
     m_teleview:publish_event(reset, TeleviewId, RendererId, #{}, Context),
 
-    {ok, #state{min_time=maps:get(differ_min_time, Args, ?DEFAULT_MIN_TIME),
-                max_time=maps:get(differ_max_time, Args, ?DEFAULT_MAX_TIME),
+    {ok, #state{min_time=maps:get(keyframe_min_time, Args, ?DEFAULT_MIN_TIME),
+                max_time=maps:get(keyframe_max_time, Args, ?DEFAULT_MAX_TIME),
                 teleview_id=TeleviewId,
                 renderer_id=RendererId,
                 context=Context}}.
@@ -120,9 +120,6 @@ handle_call({new_frame, Frame}, _From, #state{processing=false}=State) ->
 handle_call({sync_new_frame, Frame}, _From, #state{}=State) ->
     {_Patch, State1} = next_patch(Frame, State),
     {reply, ok, State1#state{processing=false, new_frame=undefined}};
-
-handle_call(state, _From, State) ->
-    {reply, differ_state(State), State};
 
 handle_call(keyframe, _From, State) ->
     {reply, State#state.keyframe, State};
@@ -318,15 +315,4 @@ patch_to_list([{skip, N} | Rest], Acc) ->
 patch_to_list([{insert, Bin} | Rest], Acc) ->
     patch_to_list(Rest, [Bin, i | Acc]).
 
-
-differ_state(#state{}=State) ->
-    #{keyframe => State#state.keyframe,
-      keyframe_sn => State#state.keyframe_sn,
-      current_frame => State#state.current_frame,
-      current_frame_sn => State#state.current_frame_sn,
-      min_time => State#state.min_time,
-      max_time => State#state.max_time,
-      teleview_id => State#state.teleview_id,
-      renderer_id => State#state.renderer_id
-     }.
 

--- a/src/support/z_teleview_render.erl
+++ b/src/support/z_teleview_render.erl
@@ -100,7 +100,7 @@ handle_call({render, Args}, _From, #state{processing = true}=State) ->
     %%
     %% Note, the diff_tries is not updated. It could be that the differ is too
     %% slow, and can't keep up with the pace of the updates.
-    lager:warning("Renderer is waiting for differ, but accepting new render.", []),
+    lager:warning("Renderer is waiting for differ, but accepting new render request.", []),
     {reply, ok, State#state{
                   render_result = undefined,
                   render_args = Args}};

--- a/src/support/z_teleview_render.erl
+++ b/src/support/z_teleview_render.erl
@@ -185,11 +185,13 @@ diff_wait_time(N) ->
 
 % Render the template with the supplied vars and send the result to the differ.
 render(Args, #state{template=Template, args=RenderArgs, render_context=Context}) ->
-    Args1 = merge_args(RenderArgs, Args),
-    {IOList, _Context} = z_template:render_to_iolist(Template, Args1, Context),
-    Result = z_convert:to_binary(IOList),
-    z_depcache:flush_process_dict(),
-    Result.
+    try
+        Args1 = merge_args(RenderArgs, Args),
+        {IOList, _Context} = z_template:render_to_iolist(Template, Args1, Context),
+        z_convert:to_binary(IOList)
+    after 
+        z_depcache:flush_process_dict()
+    end.
 
  
 % Get the pid of the differ from the supervisor.

--- a/src/support/z_teleview_render.erl
+++ b/src/support/z_teleview_render.erl
@@ -114,9 +114,9 @@ handle_call({render, Args}, _From, #state{processing = false}=State) ->
 
 handle_call({sync_render, Args}, _From, #state{}=State) ->
     RenderResult = render(Args, State),
-    DifferState = z_teleview_differ:sync_new_frame(State#state.differ_pid, RenderResult),
+    ok = z_teleview_differ:sync_new_frame(State#state.differ_pid, RenderResult),
     State1 = State#state{diff_tries = 0, render_result = undefined, render_args=undefined, processing=false},
-    {reply, DifferState, State1};
+    {reply, ok, State1};
 
 
 handle_call(Msg, _From, State) ->

--- a/src/support/z_teleview_state.erl
+++ b/src/support/z_teleview_state.erl
@@ -29,7 +29,11 @@
 
     init_table/1,
     store_current_frame/5,
+    get_current_frame/3,
+
     store_keyframe/5,
+    get_keyframe/3, 
+
     delete_frames/3
 ]).
 
@@ -99,10 +103,31 @@ store_current_frame(TeleviewId, RendererId, Frame, Sn, Context) ->
     Table = table_name(Context),
     ets:insert(Table, {{current_frame, TeleviewId, RendererId}, Frame, Sn}).
 
+get_current_frame(TeleviewId, RendererId, Context) ->
+    Table = table_name(Context),
+    case ets:lookup(Table, {current_frame, TeleviewId, RendererId}) of
+        [] ->
+            undefined;
+        [{_Key, Frame, Sn}] ->
+            #{ current_frame => Frame,
+               current_frame_sn => Sn }
+    end.
+
 % @doc Store the keyframe of a renderer.
 store_keyframe(TeleviewId, RendererId, Frame, Sn, Context) ->
     Table = table_name(Context),
     ets:insert(Table, {{keyframe, TeleviewId, RendererId}, Frame, Sn}).
+
+get_keyframe(TeleviewId, RendererId, Context) ->
+    Table = table_name(Context),
+    case ets:lookup(Table, {keyframe, TeleviewId, RendererId}) of
+        [] ->
+            undefined;
+        [{_Key, Frame, Sn}] ->
+            #{ keyframe => Frame,
+               keyframe_sn => Sn }
+    end.
+
 
 % @doc Remove the current and keyframe of a renderer.
 delete_frames(TeleviewId, RendererId, Context) ->

--- a/src/support/z_teleview_state.erl
+++ b/src/support/z_teleview_state.erl
@@ -83,6 +83,7 @@ start_renderer(TeleviewId, VaryArgs, Context) ->
         true ->
             {ok, RendererId};
         false ->
+            %% Ensure access from this session to the teleview.
             gen_server:call({via, z_proc, {{?MODULE, TeleviewId}, Context}},
                             {start_renderer, VaryArgs, z_context:prune_for_scomp(Context)})
     end.
@@ -124,6 +125,7 @@ get_current_frame(TeleviewId, RendererId, Context) ->
     Table = table_name(Context),
     case ets:lookup(Table, {current_frame, TeleviewId, RendererId}) of
         [] ->
+            ?DEBUG(no_frame),
             undefined;
         [{_Key, Frame, Sn}] ->
             #{ current_frame => Frame,

--- a/src/support/z_teleview_state.erl
+++ b/src/support/z_teleview_state.erl
@@ -73,17 +73,34 @@ start_link(Id, Supervisor, Args, Context) ->
 
 
 % @doc Start a renderer.
+-spec start_renderer(integer(), map(), zotonic:context()) -> {ok, integer()} | {error, _}.
 start_renderer(TeleviewId, VaryArgs, Context) ->
-    gen_server:call({via, z_proc, {{?MODULE, TeleviewId}, Context}},
-                    {start_renderer, VaryArgs, z_context:prune_for_scomp(Context)}).
+
+    %% Generate a stable renderer id from the id of the teleview and the vary args of the renderer
+    RendererId = mod_teleview:renderer_id(TeleviewId, VaryArgs),
+
+    case is_renderer_already_started(TeleviewId, RendererId, Context) of
+        true ->
+            {ok, RendererId};
+        false ->
+            gen_server:call({via, z_proc, {{?MODULE, TeleviewId}, Context}},
+                            {start_renderer, VaryArgs, z_context:prune_for_scomp(Context)})
+    end.
+
 
 % @doc Tell the teleview state process to keep the renderer alive
 keep_alive(TeleviewId, RendererId, Context) ->
     gen_server:cast({via, z_proc, {{?MODULE, TeleviewId}, Context}}, {keep_alive, RendererId}).
 
 
+% @doc Return true when the renderer is already started.
+is_renderer_already_started(TeleviewId, RendererId, Context) ->
+    is_pid(z_proc:whereis({z_teleview_renderer_sup, TeleviewId, RendererId}, Context)).
+
+
 %%
-%% Teleview Ets State. This table is shared by all televiews.
+%% Teleview Ets State. This table is shared by all televiews. It contains the frames
+%% of the different renderers.
 %%
 
 init_table(Context) ->
@@ -119,7 +136,6 @@ store_keyframe(TeleviewId, RendererId, Frame, Sn, Context) ->
     ets:insert(Table, {{keyframe, TeleviewId, RendererId}, Frame, Sn}).
 
 get_keyframe(TeleviewId, RendererId, Context) ->
-    ?DEBUG({keyframe, TeleviewId, RendererId}),
     Table = table_name(Context),
     case ets:lookup(Table, {keyframe, TeleviewId, RendererId}) of
         [] ->
@@ -174,11 +190,10 @@ handle_call({start_renderer, VaryArgs, Context}, _From,
 
             %% Trigger a synchronized render, and return the renderstate so it can be 
             %% put on the page immediately
-            RendererState = z_teleview_render:sync_render(State#state.id, RendererId, State#state.args, Context),
-            {reply, {ok, RendererState}, State#state{no_renderers_count=0, renderers=Renderers1}};
+            ok = z_teleview_render:sync_render(State#state.id, RendererId, State#state.args, Context),
+            {reply, {ok, RendererId}, State#state{no_renderers_count=0, renderers=Renderers1}};
         {error, {already_started, _Pid}} ->
-            RendererState = z_teleview_differ:state(State#state.id, RendererId, Context),
-            {reply, {ok, RendererState}, State#state{no_renderers_count=0}};
+            {reply, {ok, RendererId}, State#state{no_renderers_count=0}};
         {error, Error} ->
             {reply, {error, {could_not_start, Error}}, State}
     end;

--- a/src/support/z_teleview_state.erl
+++ b/src/support/z_teleview_state.erl
@@ -119,12 +119,13 @@ store_keyframe(TeleviewId, RendererId, Frame, Sn, Context) ->
     ets:insert(Table, {{keyframe, TeleviewId, RendererId}, Frame, Sn}).
 
 get_keyframe(TeleviewId, RendererId, Context) ->
+    ?DEBUG({keyframe, TeleviewId, RendererId}),
     Table = table_name(Context),
     case ets:lookup(Table, {keyframe, TeleviewId, RendererId}) of
         [] ->
             undefined;
         [{_Key, Frame, Sn}] ->
-            #{ keyframe => Frame,
+            #{ frame => Frame,
                keyframe_sn => Sn }
     end.
 


### PR DESCRIPTION
The teleview client side must do a lazy init. This means that the keyframe and current_frame are not supplied when the teleview is initialised. It must get the keyframe or current_frame when it receives its first patch.

When a teleview is rendered on the page, the current frame should be retrieved from the ets table. When the teleview client receives a patch, it should do a get to retrieve the keyframe and current frame

- [x] Keyframe in ets.
- [x] Current frame in ets.
- [x] Model get to retrieve keyframe
- [x] Model get to retrieve current frame
- [x] Client side retrieves either keyframe or current frame from new model calls.
- [x] Teleview initialisation does not return keyframe or current frame.
- [x] Client side can restart server side