### PR TITLE
Make the tag and class of the teleview wrapper configurable

### DIFF
--- a/priv/lib/js/zotonic.teleview.worker.js
+++ b/priv/lib/js/zotonic.teleview.worker.js
@@ -77,7 +77,7 @@ model.present = function(proposal) {
             cotonic.mqtt.fill("model/ui/insert/+id", model),
             {
                 initialData: undefined,
-                inner: false,
+                inner: true,
                 priority: 10
             }
         );
@@ -302,10 +302,7 @@ state.representation = function(model) {
     if(!state.hasCurrentFrame(model)) return;
     if(!state.isPageVisible(model)) return;
 
-    return `<div id="${ model.id }" data-teleview-id="${ model.teleview_id }" data-renderer-id="${ model.renderer_id }">
-${ fromUTF8(model.current_frame) }
-</div>`;
-
+    return fromUTF8(model.current_frame);
 }
 
 state.nextAction = function(model) {


### PR DESCRIPTION
Via two new attributes to the teleview scomp it is now possible to set custom wrapper element and class to the teleview on the page.

`teleview_wrapper_element` (default "div")
`teleview_wrapper_class` (no default, omitted)